### PR TITLE
 Make preview functionality work in Rails 6.0.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Add Rails 6 support for previews
+
 ## [0.2.0] - 2019-08-30
 
 - Add Rails 6 support

--- a/lib/mail/notify/mailers_controller.rb
+++ b/lib/mail/notify/mailers_controller.rb
@@ -25,7 +25,7 @@ module Mail
 
       def render_preview_wrapper
         @part = @email
-        render action: 'email', layout: false, formats: %w[html]
+        render action: 'email', layout: false, formats: %i[html]
       end
 
       def notify?

--- a/lib/mail/notify/railtie.rb
+++ b/lib/mail/notify/railtie.rb
@@ -9,7 +9,7 @@ module Mail
 
       initializer 'mail-notify.action_controller' do
         ActiveSupport.on_load(:action_controller, run_once: true) do
-          Rails::MailersController.send(:prepend, Mail::Notify::MailersController)
+          Rails::MailersController.prepend(Mail::Notify::MailersController)
         end
       end
     end

--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'coveralls', '~> 0.8.22'
   spec.add_development_dependency 'pry', '~> 0.12.0'
-  spec.add_development_dependency 'rails', '~> 5.2'
+  spec.add_development_dependency 'rails', '~> 6.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails', '~> 3.8'
   spec.add_development_dependency 'rubocop', '~> 0.63'

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationController < ActionController::Base
+end


### PR DESCRIPTION
Currently the mail preview functionality raises an error in Rails 6.

<img width="1345" alt="Screenshot 2019-10-21 at 20 39 31" src="https://user-images.githubusercontent.com/233676/67237307-eb0c9500-f442-11e9-87d0-2d0b2a98d843.png">
 
This is caused by a Rails 6.0.0 introducing a check on the `formats` that you can render in  https://github.com/rails/rails/pull/35661.

Since that commit, you can only specify the `formats` as symbols, not strings. The render statement in the actionmailer controller was updated in the PR as well:

https://github.com/rails/rails/pull/35661/files#diff-32907ca93d739460000a3f554515caa4

This PR:

- Upgrades the dummy app to Rails 6 and fixes some test breakage
- Fixes the bug

The fix is used in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/354.