### PR TITLE
Add GOV.UK Notify styling for mailer previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog]
 ## [Unreleased]
 
 - Add Rails 6 support for previews
+- Add GOV.UK Notify styling to preview emails
 
 ## [0.2.0] - 2019-08-30
 

--- a/lib/mail/notify/layouts/govuk_notify_layout.html.erb
+++ b/lib/mail/notify/layouts/govuk_notify_layout.html.erb
@@ -1,0 +1,153 @@
+<%# Copied from GOV.UK Notify: https://raw.githubusercontent.com/alphagov/notifications-utils/d69de041d1be7b826e7d9cc56450e157ad361799/notifications_utils/jinja_templates/email_template.jinja2 %>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta content="telephone=no" name="format-detection" /> <!-- need to add formatting for real phone numbers -->
+  <meta name="viewport" content="width=device-width" />
+  <title>Page title</title>
+
+  <style type="text/css">
+    @media only screen and (min-device-width: 581px) {
+      .content {
+        width: 580px !important;
+      }
+    }
+    body { margin:0 !important; }
+    div[style*="margin: 16px 0"] { margin:0 !important; }
+  </style>
+
+  <!--[if gte mso 9]>
+    <style type="text/css">
+      li {
+        margin-left: 4px !important;
+      }
+      table {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
+    </style>
+  <![endif]-->
+
+</head>
+
+<body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
+
+<span style="display: none;font-size: 1px;color: #fff; max-height: 0;"></span>
+  <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td width="100%" height="53" bgcolor="#0b0c0c">
+        <!--[if (gte mso 9)|(IE)]>
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
+            <tr>
+              <td>
+        <![endif]-->
+        <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+          <tr>
+            <td width="70" bgcolor="#0b0c0c" valign="middle">
+              <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                  <tr>
+                    <td style="padding-left: 10px">
+                      <img
+                        src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
+                        alt=" "
+                        height="32"
+                        border="0"
+                        style="Margin-top: 4px;"
+                      />
+                    </td>
+                    <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 10px;">
+                      <span style="
+                        font-family: Helvetica, Arial, sans-serif;
+                        font-weight: 700;
+                        color: #ffffff;
+                        text-decoration: none;
+                        vertical-align:top;
+                        display: inline-block;
+                          ">GOV.UK</span>
+                    </td>
+                  </tr>
+                </table>
+              </a>
+            </td>
+          </tr>
+        </table>
+        <!--[if (gte mso 9)|(IE)]>
+              </td>
+            </tr>
+          </table>
+        <![endif]-->
+      </td>
+    </tr>
+  </table>
+  <table
+      role="presentation"
+      class="content"
+      align="center"
+      cellpadding="0"
+      cellspacing="0"
+      border="0"
+      style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+      width="100%"
+  >
+    <tr>
+      <td width="10" height="10" valign="middle"></td>
+      <td>
+        <!--[if (gte mso 9)|(IE)]>
+          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+            <tr>
+              <td height="10">
+        <![endif]-->
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+                  <tr>
+                    <td bgcolor="#005EA5" width="100%" height="10"></td>
+                  </tr>
+                </table>
+        <!--[if (gte mso 9)|(IE)]>
+              </td>
+            </tr>
+          </table>
+        <![endif]-->
+      </td>
+      <td width="10" valign="middle" height="10"></td>
+    </tr>
+  </table>
+
+  <table
+      role="presentation"
+      class="content"
+      align="center"
+      cellpadding="0"
+      cellspacing="0"
+      border="0"
+      style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
+      width="100%"
+  >
+    <tr>
+      <td height="30"><br /></td>
+    </tr>
+    <tr>
+      <td width="10" valign="middle"><br /></td>
+      <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
+        <!--[if (gte mso 9)|(IE)]>
+          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
+            <tr>
+              <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
+        <![endif]-->
+            <%= yield %>
+        <!--[if (gte mso 9)|(IE)]>
+              </td>
+            </tr>
+          </table>
+        <![endif]-->
+      </td>
+      <td width="10" valign="middle"><br /></td>
+    </tr>
+    <tr>
+      <td height="30"><br /></td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/lib/mail/notify/mailers_controller.rb
+++ b/lib/mail/notify/mailers_controller.rb
@@ -19,8 +19,12 @@ module Mail
       private
 
       def render_part
+        # Add the current directory to the view path so that Rails can find
+        # the `govuk_notify_layout` layout
+        append_view_path(__dir__)
+
         response.content_type = 'text/html'
-        render plain: @email.preview.html.html_safe
+        render html: @email.preview.html.html_safe, layout: 'govuk_notify_layout'
       end
 
       def render_preview_wrapper

--- a/spec/controllers/mailers_controller_spec.rb
+++ b/spec/controllers/mailers_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Rails::MailersController, type: :controller do
     it 'gets the HTML preview' do
       get :preview, params: { path: 'welcome/my_mail', part: 'text/html' }
 
-      expect(response.body).to eq('<p>Some HTML</p>')
+      expect(response.body).to include('<p>Some HTML</p>')
     end
 
     it 'returns a HTML content type' do


### PR DESCRIPTION
This adds a layout for displaying the emails in the standard GOV.UK Notify template. To get the layout, I've copied the [jinja template that Notify itself uses](https://raw.githubusercontent.com/alphagov/notifications-utils/d69de041d1be7b826e7d9cc56450e157ad361799/notifications_utils/jinja_templates/email_template.jinja2). I've removed the conditionals and the branding feature.

It looks like this:

<img width="1056" alt="Screenshot 2019-10-21 at 22 32 28" src="https://user-images.githubusercontent.com/233676/67245107-1e572000-f453-11e9-9fbb-f043c735a8da.png">
