### PR TITLE
Bump notifications-ruby-client gem

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3', '~> 1.4.1'
 
   spec.add_dependency 'actionmailer', '>= 5.0', '< 6.1'
-  spec.add_dependency 'notifications-ruby-client', '~> 3.1'
+  spec.add_dependency 'notifications-ruby-client', '~> 4.0.0'
 end


### PR DESCRIPTION
Version 3.1 has a bug where an error response from Notify is not correctly parsed, resulting in the exception message String being set to an array, which causes error tracking tools like Rollbar or Sentry to complain. This was fixed in the latest release (see https://github.com/alphagov/notifications-ruby-client/commit/52399fb11221b7944fe8a59b7145c49ef8bd3f67).