### PR TITLE
Correct parameter name for personalisations to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class MyMailer < Mail::Notify::Mailer
     def send_email
         template_mail('YOUR_TEMPLATE_ID_GOES_HERE',
           to: 'mail@somewhere.com',
-          personalisations: {
+          personalisation: {
               foo: 'bar'
           }
         )


### PR DESCRIPTION
* I ran into a problem where I was sending a parameter called `personalisations` with some values and all looked OK. I got a `Mail::Message` object in response, but nothing was received from Notify and Notify did not log any errors.
* On breaking down what the gem was doing I found that the email is sent correctly when the pluralisation of this field name is lost. I found this by reading through the Notify docs: https://docs.notifications.service.gov.uk/ruby.html#send-an-email-arguments-personalisation-optional and realising I had put the plural as that's what the README says.
* A better fix would be some error handling and validation for known key names but I haven't time to get stuck in I'm afraid.