### PR TITLE
Fix README typo in argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ class MyMailer < Mail::Notify::Mailer
     def send_email
         template_mail('YOUR_TEMPLATE_ID_GOES_HERE',
           to: 'mail@somewhere.com',
-          personalisations: {
+          personalisation: {
               foo: 'bar'
           }
         )


### PR DESCRIPTION
Should be `personalisation` not `personalisations` as per https://github.com/dxw/mail-notify/blob/97d28b9b886746f6564b5e08730960c5113abfb2/spec/dummy/app/mailers/welcome_mailer.rb#L14