### PR TITLE
Bump notifications-ruby-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Bump Notify gem to 5.1
 - Add error handling for blank variables
 
 ## [0.2.1] - 2019-10-22
@@ -33,7 +34,7 @@ The format is based on [Keep a Changelog]
 
 ## [0.0.1] - 2019-02-01
 
-- Inital release
+- Initial release
 
 [unreleased]:
   https://github.com/DFE-Digital/dfe-teachers-payment-service/compare/0.1.0...HEAD

--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3', '~> 1.4.1'
 
   spec.add_dependency 'actionmailer', '>= 5.0', '< 6.1'
-  spec.add_dependency 'notifications-ruby-client', '~> 4.0.0'
+  spec.add_dependency 'notifications-ruby-client', '~> 5.1'
 end


### PR DESCRIPTION
This allows updating to 5.1.1, which fixes an issue that prevents the exception message from being picked up by Sentry.

https://github.com/alphagov/notifications-ruby-client/blob/master/CHANGELOG.md#511

I’ve made the requirement looser so users can bump the gem to any version that shouldn’t be breaking (< 6).

The breaking change between 4 and 5 is that the gem drops support for Ruby 2.3. Perhaps we should take this opportunity to upgrade the [version this gem is tested against](https://github.com/tijmenb/mail-notify/blob/41d56ba15840eba33c168f6169a190636052e06c/.travis.yml#L5-L6) too 