### PR TITLE
Make tests more robust

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails', '~> 3.8'
   spec.add_development_dependency 'rubocop', '~> 0.63'
   spec.add_development_dependency 'sqlite3', '~> 1.4.1'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
 
   spec.add_dependency 'actionmailer', '>= 5.0', '< 6.1'
   spec.add_dependency 'notifications-ruby-client', '~> 5.1'

--- a/spec/mail/message_spec.rb
+++ b/spec/mail/message_spec.rb
@@ -3,11 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Mail::Message do
+  let(:api_key) do
+    'staging-e1f4c969-b675-4a0d-a14d-623e7c2d3fd8-24fea27b-824e-4259-b5ce-1badafe98150'
+  end
+
   before do
     ActionMailer::Base.add_delivery_method(:notify, Mail::Notify::DeliveryMethod)
     ActionMailer::Base.delivery_method = :notify
     ActionMailer::Base.notify_settings = {
-      api_key: 'some-api-key'
+      api_key: api_key
     }
   end
 
@@ -15,8 +19,12 @@ RSpec.describe Mail::Message do
 
   describe '#preview' do
     it 'calls preview on the delivery method' do
-      expect(message.delivery_method).to receive(:preview).with(message)
+      stub = stub_request(:post, 'https://api.notifications.service.gov.uk/v2/template/template-id/preview')
+             .to_return(status: 200, body: {}.to_json)
+
       message.preview
+
+      expect(stub).to have_been_requested
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ Coveralls.wear!
 require 'bundler/setup'
 require 'action_mailer'
 require 'pry'
+require 'webmock/rspec'
 
 require 'mail/notify'
 require 'support/test_mailer'


### PR DESCRIPTION
Rather than testing that the client recieves the correct arguments, we should really be testing  gainst what gets sent to the API. This makes us more sensitive to changes to the client and the  PI, so it's easier to handle updates to the client.