### PR TITLE
Support additional base URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ config.action_mailer.notify_settings = {
 }
 ```
 
+If you're using a different Notify service to GOV.UK Notify (for example [GOV.CA Notify](https://notification.alpha.canada.ca/)), you can also specify the Base URL in your setup:
+
+```ruby
+config.action_mailer.delivery_method = :notify
+config.action_mailer.notify_settings = {
+  api_key: YOUR_NOTIFY_API_KEY,
+  base_url: 'https://api.notification.alpha.canada.ca'
+}
+```
+
 ### Mailers
 
 There are two options for using `Mail::Notify`, either templating in Rails with a view, or templating in Notify. Whichever way you choose, you'll need your mailers to inherit from `Mail::Notify::Mailer` like so:

--- a/lib/mail/notify/delivery_method.rb
+++ b/lib/mail/notify/delivery_method.rb
@@ -26,7 +26,7 @@ module Mail
       private
 
       def client
-        @client ||= Notifications::Client.new(@settings[:api_key])
+        @client ||= Notifications::Client.new(@settings[:api_key], @settings[:base_url])
       end
 
       def email_params

--- a/spec/controllers/mailers_controller_spec.rb
+++ b/spec/controllers/mailers_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rails::MailersController, type: :controller do
   let(:preview) { double(Notifications::Client::TemplatePreview) }
 
   before do
-    allow(Notifications::Client).to receive(:new).with('some-api-key') { notify }
+    allow(Notifications::Client).to receive(:new).with('some-api-key', nil) { notify }
     allow(notify).to receive(:generate_template_preview).with(
       'template-id',
       personalisation: {

--- a/spec/mail/notify/delivery_method_spec.rb
+++ b/spec/mail/notify/delivery_method_spec.rb
@@ -132,4 +132,34 @@ RSpec.describe Mail::Notify::DeliveryMethod do
       expect(stub).to have_been_requested
     end
   end
+
+  context 'when a base url is specified' do
+    before do
+      ActionMailer::Base.notify_settings = {
+        api_key: api_key,
+        base_url: 'http://example.com'
+      }
+    end
+
+    let(:personalisation) do
+      {
+        body: "# bar\r\n\r\nBar baz",
+        subject: 'Hello there!'
+      }
+    end
+
+    let!(:stub) do
+      stub_request(:post, 'http://example.com/v2/notifications/email')
+        .with(body: request_body)
+        .to_return(body: {
+          id: 'aceed36e-6aee-494c-a09f-88b68904bad6'
+        }.to_json)
+    end
+
+    it 'calls appends the new base url to the request' do
+      mailer.deliver!
+
+      expect(stub).to have_been_requested
+    end
+  end
 end


### PR DESCRIPTION
A fork of GOV.UK Notify is now being used in Canada, so this provides support for that version (and other potential new ones) to be used too.