### PR TITLE
Explicitly pin minimum versions of dependencies

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -34,5 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.7.6"
 
   spec.add_dependency "actionmailer", ">= 5.2.4.2", "< 6.1"
+  spec.add_dependency "activesupport", ">= 5.2.4.3"
+  spec.add_dependency "actionpack", ">= 5.2.4.3"
   spec.add_dependency "notifications-ruby-client", "~> 5.1"
 end


### PR DESCRIPTION
This pins minimum versions of `activesupport` and `actionpack` to resolve open security advisories.