### PR TITLE
Pin Standard.rb version

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rails", "~> 6.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec-rails", "~> 3.8"
-  spec.add_development_dependency "standard", "~> 0.2"
+  spec.add_development_dependency "standard", "0.4.7"
   spec.add_development_dependency "sqlite3", "~> 1.4.1"
   spec.add_development_dependency "webmock", "~> 3.7.6"
 

--- a/spec/controllers/mailers_controller_spec.rb
+++ b/spec/controllers/mailers_controller_spec.rb
@@ -38,8 +38,9 @@ RSpec.describe Rails::MailersController, type: :controller do
     it "returns an iframe" do
       get :preview, params: {path: "welcome/my_mail"}
 
-      regex = %r{<iframe seamless name="messageBody" src="\?part=text%2Fhtml"><\/iframe>}
-      expect(response.body).to match(regex)
+      expect(response.body).to include(
+        "<iframe seamless name=\"messageBody\" src=\"?part=text%2Fhtml\"></iframe>"
+      )
     end
   end
 end


### PR DESCRIPTION
This means that we can rely on Dependabot to keep Standard up to date and fix any issues alongside the version bump.