### PR TITLE
Remove pessimistic constraint on Rails version

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3", "~> 1.4.1"
   spec.add_development_dependency "webmock", "~> 3.7.6"
 
-  spec.add_dependency "actionmailer", ">= 5.2.4.2", "< 6.2"
+  spec.add_dependency "actionmailer", ">= 5.2.4.3"
   spec.add_dependency "activesupport", ">= 5.2.4.3"
   spec.add_dependency "actionpack", ">= 5.2.4.3"
   spec.add_dependency "actionview", ">= 5.2.4.3"


### PR DESCRIPTION
The Rails api that mail-notify to add a delivery method is extremely stable and is unlikely to change so the pessimistic constraint doesn't bring any benefit and can prevent automated dependency tools like dependabot from opening PRs when upgrades are available.

The Rails core team also encourages removal of these constraints since they prevent working with prerelease versions of Rails and makes discovery of any issues harder.