### PR TITLE
Allowing explicitly blank personalisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ class MyMailer < Mail::Notify::Mailer
 end
 ```
 
+By default, any blank personalisation are removed from the request, which will trigger mail template validation. This is to avoid accidental blanks in the email. If you want to send a blank value, you need to explicitly state that the personalization can be blank:  
+
+```ruby
+class MyMailer < Mail::Notify::Mailer
+  def send_email
+    template_mail('YOUR_TEMPLATE_ID_GOES_HERE',
+                  to: 'mail@somewhere.com',
+                  personalisation: {
+                    foo: foo.name, # This will trigger template validation error when blank
+                    bar: blank_allowed(bar.name) # This will inject empty string in the template when blank
+                  }
+    )
+  end
+end
+```
+
+
 #### With optional Notify arguments
 
 It's possible to pass two optional arguments to Notify:

--- a/lib/mail/notify/mailer.rb
+++ b/lib/mail/notify/mailer.rb
@@ -14,6 +14,10 @@ module Mail
 
         mail(headers.merge(body: "", subject: "", template_id: template_id))
       end
+
+      def blank_allowed(value)
+        value.presence || Personalisation::BLANK
+      end
     end
   end
 end

--- a/lib/mail/notify/personalisation.rb
+++ b/lib/mail/notify/personalisation.rb
@@ -3,6 +3,8 @@
 module Mail
   module Notify
     class Personalisation
+      BLANK = Object.new
+
       def initialize(mail)
         @body = mail.body.raw_source
         @subject = mail.subject
@@ -10,7 +12,9 @@ module Mail
       end
 
       def to_h
-        merged_options.reject { |_k, v| v.blank? }
+        merged_options
+          .reject { |_k, v| v.blank? }
+          .transform_values { |value| value == BLANK ? "" : value }
       end
 
       private

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe Mail::Notify::Mailer do
       )
     end
   end
+
+  describe "#blank_allowed" do
+    context "when given a non-blank value" do
+      it "returns the given value" do
+        expect(mailer.blank_allowed("foo")).to eq "foo"
+      end
+    end
+
+    context "when given a blank value" do
+      it "returns explicitly blank personalisation" do
+        expect(mailer.blank_allowed("")).to be Mail::Notify::Personalisation::BLANK
+      end
+    end
+  end
 end

--- a/spec/mail/notify/personalisation_spec.rb
+++ b/spec/mail/notify/personalisation_spec.rb
@@ -45,4 +45,20 @@ RSpec.describe Mail::Notify::Personalisation do
       )
     end
   end
+
+  context "with explicitly blank personalisation" do
+    let(:mail) { Mail.new(personalisation: {foo: Mail::Notify::Personalisation::BLANK}) }
+
+    it "replaces it with a blank string" do
+      expect(personalisation.to_h).to eq("foo" => "")
+    end
+  end
+
+  context "with implicitly blank personalisation" do
+    let(:mail) { Mail.new(personalisation: {foo: [nil, "", false].sample}) }
+
+    it "removes it from the hash" do
+      expect(personalisation.to_h).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Notify API allows sending blank, optional personalisations, however this gem prevents this by removing all the blanks before the request is sent.

In this PR I'd like to propose allowing this, however requesting that sending a blank personalisation should be done explicitly to avoid emails being sent without all the key values interpolated. This also makes the change backward compatible.

### Usage

To mark personalisation as possibly blank, one can use `blank_allowed` method in the mailer:

```
template_mail(
  ...,
  personalisation: {
    name: user.name #=> This personalisation is required, causing Notify `missing personalisation` error response if name is missing (and if template really requires it)
    note: allow_blank(note) #=> This personalisation is made optional. If `note` is blank, it will be replaced with empty string.
}
```