### PR TITLE
Fix Rubygems script

### DIFF
--- a/.github/setup-rubygems.sh
+++ b/.github/setup-rubygems.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-mkdir ~/.gem
+mkdir -p ~/.gem
 echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials


### PR DESCRIPTION
The `~/.gem` folder seems to exist in certain states, so add a `-p` flag to only create if it doesn’t exist.