### PR TITLE
Unpin rspec mocks

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -34,10 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard", "~> 1"
   spec.add_development_dependency "sqlite3", "~> 1.6.2"
   spec.add_development_dependency "webmock", "~> 3.16.0"
-  # Note: we pin rspec-mocks only because 3.10.3 is broken; see
-  # https://github.com/rspec/rspec-mocks/issues/1460
-  # and the commit message for this commit
-  spec.add_development_dependency "rspec-mocks", "3.10.2"
+  spec.add_development_dependency "rspec-mocks", "~> 3.11.0"
 
   spec.add_dependency "actionmailer", ">= 5.2.4.6"
   spec.add_dependency "activesupport", ">= 5.2.4.6"

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Mail::Notify::Mailer do
 
   context "with a view" do
     it "sends the template" do
-      expect(mailer).to receive(:mail).with(template_id: "foo", bar: "baz")
+      expect(mailer).to receive(:mail).with({template_id: "foo", bar: "baz"})
       mailer.view_mail("foo", bar: "baz")
     end
 
@@ -21,12 +21,12 @@ RSpec.describe Mail::Notify::Mailer do
 
   context "with a template" do
     it "sends a blank body and subject" do
-      expect(mailer).to receive(:mail).with(
+      expect(mailer).to receive(:mail).with({
         template_id: "foo",
         bar: "baz",
         body: "",
         subject: ""
-      )
+      })
       mailer.template_mail("foo", bar: "baz")
     end
 


### PR DESCRIPTION
This is an interesting one! We have pinned rspec-mocks to a version that doesn't have this issue, but the actual fix is to fix the spec.

I believe the issue strangely relates to the Ruby version. The way arguments are passed changed and rspec-mocks follows the Ruby 3 version.

Regardless the spec itself makes use of this odd Ruby 2.x behaviour when it doesn't need to.

Looking at the implementation you can see that `mail` is called with a merged hash like this:

`mail(headers.merge(template_id: template_id))`

and so we should expect `mail` to receive a hash.

With this fixed we can support Ruby 2.x and 3.x