### PR TITLE
Pin Rails to fix test suite

### DIFF
--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "coveralls", "~> 0.8.22"
   spec.add_development_dependency "pry", "~> 0.14.1"
-  spec.add_development_dependency "rails", "~> 7"
+  spec.add_development_dependency "rails", "7.0.8"
   spec.add_development_dependency "rake", "~> 13.0.6"
   spec.add_development_dependency "rspec-rails", "~> 5.1"
   spec.add_development_dependency "standard", "~> 1"


### PR DESCRIPTION
Rails 7.1 introduces a change to the email preview template that our
testing suite  cannot handle yet, a `link_to` causes the render to
fail.

To give us the space to fix the underlying issue, we'll pin Rails at
7.0.8, this is only for the test suite, the gem can still support
other versions of Rails as the issue will not be present in actual
installaions.

With the test suite working again we can work on some other issues,
update some dependancies and come back to this link_to problem.
