### PR TITLE
Disbale the Renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
This project needs to support multiple versions of Ruby and Rails,
having a tool like Renovate trying to update depenencies without giving
the appropriate amount of forethought can cause issues.

For now we'll disable the dashboard.
