### PR TITLE
Pin Bundler version in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install sqlite3 libsqlite3-dev
-        gem install bundler
+        gem install bundler --version "2.3.27"
         bundle install --jobs 4 --retry 3 --path ./vendor/bundle
         bundle exec rake
     - name: Coveralls


### PR DESCRIPTION
Right now we want to support older versions of Ruby back to 2.7.8 but
Bundler has dropped support for 2.7.x:

https://bundler.io/v2.4/whats_new.html#old-ruby-and-rubygems-no-longer-supported

For now, we need to pin the bundler version in our build to continue.