### PR TITLE
Prevent Renovate updating Ruby version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,4 +4,5 @@
     "config:base"
   ],
   "dependencyDashboard": false
+  "ignoreDeps": ["ruby-version"]
 }


### PR DESCRIPTION
Generally we do not want to update the version of Ruby in the gem as we
want to support as many applications as possible.

To prevent the version of Ruby from being updated without consideration,
we'll prevent Renovate from opening PRs to update it.
