### PR TITLE
Fix the readme build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://github.com/dxw/mail-notify/actions/workflows/build.yml/badge.svg)](https://github.com/dxw/mail-notify/actions/workflows/build.yml)
+[![Build status](https://github.com/dxw/mail-notify/actions/workflows/ci.yml/badge.svg)](https://github.com/dxw/mail-notify/actions/workflows/ci.yml)
 [![Coverage status](https://coveralls.io/repos/github/dxw/mail-notify/badge.svg?branch=fix-coveralls)](https://coveralls.io/github/dxw/mail-notify?branch=fix-coveralls)
 [![Gem Version](http://img.shields.io/gem/v/mail-notify.svg?style=flat-square)](https://rubygems.org/gems/mail-notify)
 [![License](http://img.shields.io/:license-mit-blue.svg)](https://mit-license.org/)


### PR DESCRIPTION
We forgot this when the Github action file was renamed.