### PR TITLE
Simple Rails integration tests

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -1,0 +1,61 @@
+name: Integration tests
+
+on:
+  pull_request:
+
+jobs:
+  rails-6:
+    name: Rails 6 mailer previews
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and cache
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            RAILS_VERSION=6.1.7.6
+            MAIL_NOTIFY_BRANCH=${{ github.ref }}
+          push: false
+          load: true
+          tags: mail-notify-integration-rails-6:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      -
+        name: Run integration tests
+        run: docker run --rm -e "NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }}" mail-notify-integration-rails-6:latest
+
+  rails-7:
+    name: Rails 7 mailer previews
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build and cache
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            RAILS_VERSION=7.1.3.2
+            MAIL_NOTIFY_BRANCH=${{ github.ref }}
+          push: false
+          load: true
+          tags: mail-notify-integration-rails-7:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+      -
+        name: Run integration tests
+        run: docker run --rm -e "NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }}" mail-notify-integration-rails-7:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# We want to support older Rubies
+ARG RUBY_VERSION=2.7.8
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+
+# Rails app lives here
+WORKDIR /rails
+
+# Build stage
+FROM base as build
+
+# Install packages needed to build gems and node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential curl git
+
+# Install Nokigiri version that supports Ruby 2.7.8
+RUN gem install nokogiri -v 1.15.6
+
+# Install Rails
+ARG RAILS_VERSION=7.1.3.2
+RUN gem install rails -v ${RAILS_VERSION}
+
+# create empty Rails application, we don't need ActiveRecord or JavaScript
+RUN rails new mail-notify-integration --skip-active-record --skip-javascript
+
+WORKDIR mail-notify-integration
+
+# install the gems into the bundle
+RUN bundle install
+
+# Final stage for app image
+FROM base
+
+# Install packages needed for running the tests
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl git && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /rails /rails
+
+WORKDIR /rails/mail-notify-integration
+
+# add Mail Notify to the Gemfile
+ARG MAIL_NOTIFY_BRANCH=v2
+RUN echo "gem 'mail-notify', git: 'https://github.com/dxw/mail-notify', branch: '${MAIL_NOTIFY_BRANCH}'" >> Gemfile
+
+# install the mail-notify gem, we do this here to keep the last container layer small to help caching
+RUN bundle install
+
+# Copy over intergration test files
+COPY test/ test/
+COPY test/app/mailers/ app/mailers/
+COPY test/app/views/ app/views/
+
+# Setup the test environment
+RUN echo "Rails.application.config.action_mailer.show_previews = true" >> config/environments/test.rb
+RUN echo "Rails.application.config.action_mailer.delivery_method = :notify" >>config/environments/test.rb
+RUN echo "Rails.application.config.action_mailer.notify_settings = {api_key: ENV['NOTIFY_API_KEY']}" >> config/environments/test.rb
+
+# Run the system tests
+CMD ["./bin/rails", "test:system"]

--- a/test/app/mailers/notify_mailer.rb
+++ b/test/app/mailers/notify_mailer.rb
@@ -1,0 +1,21 @@
+class NotifyMailer < Mail::Notify::Mailer
+  def view_email
+    subject = params[:subject]
+    to = params[:to]
+
+    view_mail("8153737e-7f6c-4a6f-b33c-48d954e07257", {to: to, subject: subject})
+  end
+
+  def template_email
+    to = params[:to]
+
+    template_mail("46bec5ff-354c-4a98-8c91-277bc5d4e09b", to: to)
+  end
+
+  def template_with_personalisation
+    name = params[:name]
+    to = params[:email_address]
+
+    template_mail("5c9f8048-4283-40f8-9694-7dbb86b1f636", to: to, personalisation: {name: name})
+  end
+end

--- a/test/app/views/notify_mailer/view_email.text.erb
+++ b/test/app/views/notify_mailer/view_email.text.erb
@@ -1,0 +1,26 @@
+View email message
+
+# This is a heading
+
+## This is a subheading
+
+Introduce bullet points with a lead-in line ending in a colon:
+
+* leave one empty line space after the lead-in line
+* use an asterisk or a dash followed by a space to add an item
+* start each item with a lowercase letter, do not end with a full stop
+* leave one empty line space after the last item
+
+Introduce numbered points with a lead-in line ending in a colon:
+
+1. Leave one empty line space before starting your list.
+2. Enter a number followed by a full stop and a space to add an item.
+3. Start each item with a capital letter and end it with a full stop.
+4. Leave one empty line space after the last item.
+
+^ You must tell us if your circumstances change.
+
+First paragraph
+
+---
+Second paragraph

--- a/test/mailers/previews/notify_mailer_preview.rb
+++ b/test/mailers/previews/notify_mailer_preview.rb
@@ -1,0 +1,13 @@
+class NotifyMailerPreview < ActionMailer::Preview
+  def view_email
+    NotifyMailer.with(to: "view.email@notifications.service.gov.uk", subject: "View email subject").view_email
+  end
+
+  def template_email
+    NotifyMailer.with(to: "template.email@notifications.service.gov.uk").template_email
+  end
+
+  def template_email_with_personalisation
+    NotifyMailer.with(to: "template.email@notifications.service.gov.uk", name: "Test Name").template_with_personalisation
+  end
+end

--- a/test/system/notify_mailer_preview_test.rb
+++ b/test/system/notify_mailer_preview_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class NotifyMailerPreviewTest < ActionDispatch::SystemTestCase
+  # User rack_test not a browser
+  driven_by :rack_test
+
+  # Template email previews
+  test "previews the template email headers" do
+    visit "/rails/mailers/notify_mailer/template_email"
+
+    assert_content "Template email subject"
+    assert_content "template.email@notifications.service.gov.uk"
+  end
+
+  test "previews the template email html body" do
+    visit "/rails/mailers/notify_mailer/template_email?part=text%2Fhtml"
+
+    assert_content "Template email message."
+  end
+
+  test "previews the template email plain text body" do
+    visit "/rails/mailers/notify_mailer/template_email?part=text%2Fplain"
+
+    assert_content "Template email message."
+  end
+
+  # Template email previews with personalisation
+  test "previews the template email headers with personalisation" do
+    visit "/rails/mailers/notify_mailer/template_email_with_personalisation"
+
+    assert_content "Template email subject"
+    assert_content "template.email@notifications.service.gov.uk"
+  end
+
+  test "previews the template email html body with personalisation" do
+    visit "/rails/mailers/notify_mailer/template_email_with_personalisation?part=text%2Fhtml"
+
+    assert_content "Dear Test Name"
+    assert_content "Template email message."
+  end
+
+  test "previews the template email plain text body with personalisation" do
+    visit "/rails/mailers/notify_mailer/template_email_with_personalisation?part=text%2Fplain"
+
+    assert_content "Dear Test Name"
+    assert_content "Template email message."
+  end
+
+  # View email previews
+  test "previews the view email headers" do
+    visit "/rails/mailers/notify_mailer/view_email"
+
+    assert_content "View email subject"
+    assert_content "view.email@notifications.service.gov.uk"
+  end
+
+  test "previews the view email html body" do
+    visit "/rails/mailers/notify_mailer/view_email?part=text%2Fhtml"
+
+    assert_content "View email message"
+  end
+
+  test "previews the view email plain text" do
+    visit "/rails/mailers/notify_mailer/view_email?part=text%2Fhtml"
+
+    assert_content "View email message"
+  end
+end


### PR DESCRIPTION
We want to make sure the mailer previews work in Rails and that means we need running Rails applications with the mailers setup and previews working.

This work is formed of a Dockerfile which sets up a basic Rails application and a set of tests that exercise the mailer previews.

We can pass Rails versions and build any version we like, right now that is 6 or 7 as the dependancies for 5 makes things more complicated than it feels worth.

Running these integration tests against the current verrsion of the gem will FAIL because the current version does not actually work as intended, that is why we are working towards v2.