### PR TITLE
Run the integration tests on v2 branch

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -2,6 +2,9 @@ name: Integration tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - v2
 
 jobs:
   rails-6:


### PR DESCRIPTION
So we can see them working before v2 is released.

We should remove this once that happens.
