### PR TITLE
Fix the name of the param was missed

### DIFF
--- a/test/app/mailers/notify_mailer.rb
+++ b/test/app/mailers/notify_mailer.rb
@@ -14,7 +14,7 @@ class NotifyMailer < Mail::Notify::Mailer
 
   def template_with_personalisation
     name = params[:name]
-    to = params[:email_address]
+    to = params[:to]
 
     template_mail("5c9f8048-4283-40f8-9694-7dbb86b1f636", to: to, personalisation: {name: name})
   end


### PR DESCRIPTION
When we updated this we missed the parameter name.
