### PR TITLE
Fix ensure Notify API key for each job

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -33,7 +33,9 @@ jobs:
           cache-to: type=gha,mode=min
       -
         name: Run integration tests
-        run: docker run --rm -e "NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }}" mail-notify-integration-rails-5:latest
+        env:
+          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
+        run: docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" mail-notify-integration-rails-5:latest
   rails-6:
     name: Rails 6 mailer previews
     runs-on: ubuntu-latest
@@ -60,7 +62,9 @@ jobs:
           cache-to: type=gha,mode=min
       -
         name: Run integration tests
-        run: docker run --rm -e "NOTIFY_API_KEY=${{ secrets.NOTIFY_API_KEY }}" mail-notify-integration-rails-6:latest
+        env:
+          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
+        run: docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" mail-notify-integration-rails-6:latest
 
   rails-7:
     name: Rails 7 mailer previews


### PR DESCRIPTION
I thought I fixed this in e7e86eeb74a63580c95e653f030c4814f2d5d33b but
looks like I only did the Rails 7 job? I am working on the assumption
that once the runner has the env var set all jobs will work until the
runner shuts down as an unknown point - we'll have to see.
