### PR TITLE
Add simple send integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN bundle install
 # Copy over intergration test files
 COPY test/mailers/ test/mailers/
 COPY test/system/ test/system/
+COPY test/integration test/integration
 COPY test/application_system_test_case.rb /test/application_system_test_case.rb
 COPY test/app/mailers/ app/mailers/
 COPY test/app/views/ app/views/

--- a/test/integration/notify_mailer_sending_test.rb
+++ b/test/integration/notify_mailer_sending_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class NotifyMailerSendingTest < ActionDispatch::IntegrationTest
+  # these tests are designed to run in our integration environment and make real
+  # requests to Notify, the API key we use WILL NOT actually send any email.
+  #
+  # Once this spec runs, you will see these email in the Notify 'API Integrations'
+  # log which requires an login for our integration test Notify account and only
+  # remain for 7 days.
+  #
+  test "can send a template email" do
+    result = NotifyMailer.with(
+      to: "template.email@notifications.service.gov.uk"
+    ).template_email.deliver_now
+
+    assert result.instance_of? Mail::Message
+  end
+
+  test "can send a template email with personalisation" do
+    result = NotifyMailer.with(
+      to: "template.email@notifications.service.gov.uk",
+      name: "Test Name"
+    ).template_with_personalisation.deliver_now
+
+    assert result.instance_of? Mail::Message
+  end
+
+  test "can send a view email" do
+    result = NotifyMailer.with(
+      to: "view.email@notifications.service.gov.uk",
+      subject: "View email subject"
+    ).view_email.deliver_now
+
+    assert result.instance_of? Mail::Message
+  end
+end


### PR DESCRIPTION
We have out integration tests working well for the previews and it
follows that we can use them to test sending emails.

Whilst we cannot 'check' that Notify will do the right thing, we can
check that things appear to have gone well.

These tests use a real Notify account and the results of sending the
email will show up in the Notify console. No email is actually sent as
we use a test API key.

This work only includes the tests it does not run them in GitHub
actions, that will come next.

You can run them locally with a Notify API key:

```
docker build --build-arg RAILS_VERSION=5.2.8.1 . -t rails-5

docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" rails-5:latest bin/rails test
```
