### PR TITLE
Add integration tests for blank personalisation

### DIFF
--- a/test/app/mailers/notify_mailer.rb
+++ b/test/app/mailers/notify_mailer.rb
@@ -18,4 +18,11 @@ class NotifyMailer < Mail::Notify::Mailer
 
     template_mail("5c9f8048-4283-40f8-9694-7dbb86b1f636", to: to, personalisation: {name: name})
   end
+
+  def template_with_blank_personalisation
+    name = params[:name]
+    to = params[:to]
+
+    template_mail("5c9f8048-4283-40f8-9694-7dbb86b1f636", to: to, personalisation: {name: blank_allowed(name)})
+  end
 end

--- a/test/mailers/previews/notify_mailer_preview.rb
+++ b/test/mailers/previews/notify_mailer_preview.rb
@@ -10,4 +10,8 @@ class NotifyMailerPreview < ActionMailer::Preview
   def template_email_with_personalisation
     NotifyMailer.with(to: "template.email@notifications.service.gov.uk", name: "Test Name").template_with_personalisation
   end
+
+  def template_email_with_blank_personalisation
+    NotifyMailer.with(to: "template.email@notifications.service.gov.uk", name: nil).template_with_blank_personalisation
+  end
 end

--- a/test/system/notify_mailer_preview_test.rb
+++ b/test/system/notify_mailer_preview_test.rb
@@ -46,6 +46,28 @@ class NotifyMailerPreviewTest < ActionDispatch::SystemTestCase
     assert_content "Template email message."
   end
 
+  # Template email previews with blank personalisation
+  test "previews the template email headers with blank personalisation" do
+    visit "/rails/mailers/notify_mailer/template_email_with_blank_personalisation"
+
+    assert_content "Template email subject"
+    assert_content "template.email@notifications.service.gov.uk"
+  end
+
+  test "previews the template email html body with blank personalisation" do
+    visit "/rails/mailers/notify_mailer/template_email_with_blank_personalisation?part=text%2Fhtml"
+
+    assert_content "Dear"
+    assert_content "Template email message."
+  end
+
+  test "previews the template email plain text body with blank personalisation" do
+    visit "/rails/mailers/notify_mailer/template_email_with_blank_personalisation?part=text%2Fplain"
+
+    assert_content "Dear"
+    assert_content "Template email message."
+  end
+
   # View email previews
   test "previews the view email headers" do
     visit "/rails/mailers/notify_mailer/view_email"


### PR DESCRIPTION
We want to make sure that using `blank_allowed` for personalisation
works end to end, so we add coverage for it in our integration tests.
