### PR TITLE
(Chore) Refactor CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,34 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  lint-and-test:
-    name: Linting, specs and coverage
+  lint:
+    name: Linting
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-    - name: Run linting
-      run: bin/standardrb
-    - name: Run specs
-      run: bin/rspec
-    - name: Run coverage report
-      uses: coverallsapp/github-action@v2
-      with:
-        fail-on-error: false
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run linting
+        run: bin/standardrb
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ 2.7, 3.1, 3.2, 3.3 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run specs
+        run: bin/rspec
+      - name: Run coverage report
+        uses: coverallsapp/github-action@v2
+        with:
+          fail-on-error: false

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,9 @@
 name: Linting
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   lint:
     name: Run Standard.rb

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,15 @@
+name: Linting
+on: [push, pull_request]
+jobs:
+  lint:
+    name: Run Standard.rb
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run linting
+        run: bin/standardrb

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
+    name: Set Rails versions
     outputs:
       RAILS_VERSIONS: ${{ env.RAILS_VERSIONS }}
     steps:
@@ -24,6 +25,7 @@ jobs:
       matrix:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
+    name: Build and cache Docker containers
     needs: set-matrix
     steps:
       - name: Checkout

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -7,225 +7,74 @@ on:
       - main
 
 jobs:
-  build-rails-5:
-    name: Build Rails 5
+  build-rails:
+    strategy:
+      fail-fast: false
+      matrix:
+        rails: [ 5.2.8.1, 6.1.7.6, 7.1.3.2 ]
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Build and cache
+      - name: Build and cache
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           build-args: |
-            RAILS_VERSION=5.2.8.1
+            RAILS_VERSION=${{ matrix.rails }}
             MAIL_NOTIFY_BRANCH=${{ github.ref }}
           push: false
-          tags: mail-notify-integration-rails-5:latest
-          outputs: type=docker, dest=/tmp/rails-5-image.tar
+          tags: mail-notify-integration-rails-${{ matrix.rails }}:latest
+          outputs: type=docker, dest=/tmp/rails-${{ matrix.rails }}-image.tar
           cache-from: type=gha
           cache-to: type=gha,mode=min
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rails-5-image
-          path: /tmp/rails-5-image.tar
-
-  rails-5-previews:
-    name: Rails 5 mailer previews
+          name: rails-${{ matrix.rails }}-image
+          path: /tmp/rails-${{ matrix.rails }}-image.tar
+  mailer-previews:
+    strategy:
+      fail-fast: false
+      matrix:
+        rails: [ 5.2.8.1, 6.1.7.6, 7.1.3.2 ]
     runs-on: ubuntu-latest
-    needs: build-rails-5
+    needs: build-rails
     steps:
-      -
-        name: Download image
+      - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: rails-5-image
+          name: rails-${{ matrix.rails }}-image
           path: /tmp
-      -
-        name: Load image
-        run: docker load --input /tmp/rails-5-image.tar
-      -
-        name: Run integration tests
+      - name: Load image
+        run: docker load --input /tmp/rails-${{ matrix.rails }}-image.tar
+      - name: Run integration tests
         env:
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-5:latest bin/rails test:system
-
-
-  rails-5-sending:
-    name: Rails 5 sending
+          mail-notify-integration-rails-${{ matrix.rails }}:latest bin/rails test:system
+  sending:
+    strategy:
+      fail-fast: false
+      matrix:
+        rails: [ 5.2.8.1, 6.1.7.6, 7.1.3.2 ]
     runs-on: ubuntu-latest
-    needs: build-rails-5
+    needs: build-rails
     steps:
-      -
-        name: Download image
+      - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: rails-5-image
+          name: rails-${{ matrix.rails }}-image
           path: /tmp
-      -
-        name: Load image
-        run: docker load --input /tmp/rails-5-image.tar
-      -
-        name: Run integration tests
+      - name: Load image
+        run: docker load --input /tmp/rails-${{ matrix.rails }}-image.tar
+      - name: Run integration tests
         env:
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-5:latest bin/rails test
-
-  build-rails-6:
-    name: Build Rails 6
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and cache
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            RAILS_VERSION=6.1.7.6
-            MAIL_NOTIFY_BRANCH=${{ github.ref }}
-          push: false
-          tags: mail-notify-integration-rails-6:latest
-          outputs: type=docker, dest=/tmp/rails-6-image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: rails-6-image
-          path: /tmp/rails-6-image.tar
-
-  rails-6-previews:
-    name: Rails 6 mailer previews
-    runs-on: ubuntu-latest
-    needs: build-rails-6
-    steps:
-      -
-        name: Download image
-        uses: actions/download-artifact@v4
-        with:
-          name: rails-6-image
-          path: /tmp
-      -
-        name: Load image
-        run: docker load --input /tmp/rails-6-image.tar
-      -
-        name: Run integration tests
-        env:
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
-        run: |
-          docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-6:latest bin/rails test:system
-
-  rails-6-sending:
-    name: Rails 6 sending
-    runs-on: ubuntu-latest
-    needs: build-rails-6
-    steps:
-      -
-        name: Download image
-        uses: actions/download-artifact@v4
-        with:
-          name: rails-6-image
-          path: /tmp
-      -
-        name: Load image
-        run: docker load --input /tmp/rails-6-image.tar
-      -
-        name: Run integration tests
-        env:
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
-        run: |
-          docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-6:latest bin/rails test
-
-  build-rails-7:
-    name: Build Rails 7
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and cache
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            RAILS_VERSION=7.1.3.2
-            MAIL_NOTIFY_BRANCH=${{ github.ref }}
-          push: false
-          tags: mail-notify-integration-rails-7:latest
-          outputs: type=docker, dest=/tmp/rails-7-image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: rails-7-image
-          path: /tmp/rails-7-image.tar
-
-  rails-7-previews:
-    name: Rails 7 mailer previews
-    runs-on: ubuntu-latest
-    needs: build-rails-7
-    steps:
-      -
-        name: Download image
-        uses: actions/download-artifact@v4
-        with:
-          name: rails-7-image
-          path: /tmp
-      -
-        name: Load image
-        run: docker load --input /tmp/rails-7-image.tar
-      -
-        name: Run integration tests
-        env:
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
-        run: |
-          docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-7:latest bin/rails test:system
-
-  rails-7-sending:
-    name: Rails 7 sending
-    runs-on: ubuntu-latest
-    needs: build-rails-7
-    steps:
-      -
-        name: Download image
-        uses: actions/download-artifact@v4
-        with:
-          name: rails-7-image
-          path: /tmp
-      -
-        name: Load image
-        run: docker load --input /tmp/rails-7-image.tar
-      -
-        name: Run integration tests
-        env:
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
-        run: |
-          docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-7:latest bin/rails test
+          mail-notify-integration-rails-${{ matrix.rails }}:latest bin/rails test

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -6,13 +6,25 @@ on:
     branches:
       - main
 
+env:
+  RAILS_VERSIONS: '["5.2.8.1", "6.1.7.6", "7.1.3.2"]'
+
 jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      RAILS_VERSIONS: ${{ env.RAILS_VERSIONS }}
+    steps:
+      - name: Compute outputs
+        run: |
+          echo "RAILS_VERSIONS=${{ env.RAILS_VERSIONS }}" >> $GITHUB_OUTPUT
   build-rails:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ 5.2.8.1, 6.1.7.6, 7.1.3.2 ]
+        rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
+    needs: set-matrix
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,9 +52,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ 5.2.8.1, 6.1.7.6, 7.1.3.2 ]
+        rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
-    needs: build-rails
+    needs:
+      - set-matrix
+      - build-rails
     steps:
       - name: Download image
         uses: actions/download-artifact@v4
@@ -61,9 +75,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: [ 5.2.8.1, 6.1.7.6, 7.1.3.2 ]
+        rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
-    needs: build-rails
+    needs:
+      - set-matrix
+      - build-rails
     steps:
       - name: Download image
         uses: actions/download-artifact@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,25 +1,13 @@
-name: CI
+name: Unit tests
 on: [push, pull_request]
 jobs:
-  lint:
-    name: Linting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-      - name: Run linting
-        run: bin/standardrb
-
-  test:
+  unit-tests:
     strategy:
       fail-fast: false
       matrix:
         ruby: [ 2.7, 3.1, 3.2, 3.3 ]
     runs-on: ubuntu-latest
+    name: Run specs and coverage report
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,9 @@
 name: Unit tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   unit-tests:
     strategy:


### PR DESCRIPTION
This refactors the CI steps to run the unit tests against multiple rubies in a matrix, as well as refactors the integration tests to use a matrix too, so we can DRY them up a bit. 

Once approved, we'll need to update the required steps to the new steps so this can be merged.