### PR TITLE
(Chore) Set scope when caching

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -43,8 +43,8 @@ jobs:
           push: false
           tags: mail-notify-integration-rails-${{ matrix.rails }}:latest
           outputs: type=docker, dest=/tmp/rails-${{ matrix.rails }}-image.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-from: type=gha,scope=build-${{ matrix.rails }}
+          cache-to: type=gha,mode=min,scope=build-${{ matrix.rails }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Before we were only caching the last successfully built container, setting the scope ensures we cache each built container using the name of the matrix, so each run gets the correctly cached container