### PR TITLE
(Chore) Get latest Rails versions

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -6,23 +6,24 @@ on:
     branches:
       - main
 
-env:
-  RAILS_VERSIONS: '["5.2.8.1", "6.1.7.6", "7.1.3.2"]'
-
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
     name: Set Rails versions
     outputs:
-      RAILS_VERSIONS: ${{ env.RAILS_VERSIONS }}
+      RAILS_VERSIONS: ${{ steps.compute-outputs.outputs.RAILS_VERSIONS }}
     steps:
-      - name: Compute outputs
+      # Get latest Rails versions for 5.x.x, 6.x.x and 7.x.x
+      - id: compute-outputs
+        name: Compute outputs
         run: |
-          echo "RAILS_VERSIONS=${{ env.RAILS_VERSIONS }}" >> $GITHUB_OUTPUT
+          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq 'group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 4)' | jq -s -c)
+          echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   build-rails:
     strategy:
       fail-fast: false
       matrix:
+        # Build containers with the latest 5.x.x, 6.x.x and 7.x.x Rails versions
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
     name: Build and cache Docker containers
@@ -53,6 +54,7 @@ jobs:
   mailer-previews:
     strategy:
       fail-fast: false
+      # Run against the latest 5.x.x, 6.x.x and 7.x.x Rails versions
       matrix:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
   sending:
     strategy:
       fail-fast: false
+      # Run against the latest 5.x.x, 6.x.x and 7.x.x Rails versions
       matrix:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -96,3 +96,19 @@ jobs:
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
           mail-notify-integration-rails-${{ matrix.rails }}:latest bin/rails test
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: All integration tests
+    needs:
+      - mailer-previews
+      - sending
+    steps:
+      # If any of the previous actions failed, we return a non-zero exit code
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,3 +24,17 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           fail-on-error: false
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: All unit tests
+    needs: [ unit-tests ]
+    steps:
+      # If any of the previous actions failed, we return a non-zero exit code
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://github.com/dxw/mail-notify/actions/workflows/ci.yml/badge.svg)](https://github.com/dxw/mail-notify/actions/workflows/ci.yml)
+[![Build status](https://github.com/dxw/mail-notify/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/dxw/mail-notify/actions/workflows/unit-tests.yml)
 [![Coverage status](https://coveralls.io/repos/github/dxw/mail-notify/badge.svg?branch=fix-coveralls)](https://coveralls.io/github/dxw/mail-notify?branch=fix-coveralls)
 [![Gem Version](http://img.shields.io/gem/v/mail-notify.svg?style=flat-square)](https://rubygems.org/gems/mail-notify)
 [![Rails integration tests](https://github.com/dxw/mail-notify/actions/workflows/rails-integration-tests.yml/badge.svg)](https://github.com/dxw/mail-notify/actions/workflows/rails-integration-tests.yml)


### PR DESCRIPTION
This ensures we always run our integration tests against the latest minor / patch versions of Rails 5.x.x, 6.x.x and 7.x.x. Although Rails < 7 is not actively worked on, they still get patch updates (for security etc). I've also updated the unit tests and integration test actions to have a "Final results" step. This ensures all the Matrix tests have run successfully, so we don't have to require the status checks for each version to be up to date before merging:

### Before

![image](https://github.com/dxw/mail-notify/assets/109774/9b10ed37-51ca-49c3-9aba-acb69c8f7fd3)

### After

![image](https://github.com/dxw/mail-notify/assets/109774/308fa8e8-b776-4717-b3bc-a31632d5450c)