### PR TITLE
Drop integration tests for Ruby 2 and Rails 5

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -13,17 +13,17 @@ jobs:
     outputs:
       RAILS_VERSIONS: ${{ steps.compute-outputs.outputs.RAILS_VERSIONS }}
     steps:
-      # Get latest Rails versions for 5.x.x, 6.x.x and 7.x.x
+      # Get latest Rails versions for 6.x.x and 7.x.x
       - id: compute-outputs
         name: Compute outputs
         run: |
-          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq 'group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 4)' | jq -s -c)
+          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq 'group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 5)' | jq -s -c)
           echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   build-rails:
     strategy:
       fail-fast: false
       matrix:
-        # Build containers with the latest 5.x.x, 6.x.x and 7.x.x Rails versions
+        # Build containers with the latest 6.x.x and 7.x.x Rails versions
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
     name: Build and cache Docker containers
@@ -54,7 +54,7 @@ jobs:
   mailer-previews:
     strategy:
       fail-fast: false
-      # Run against the latest 5.x.x, 6.x.x and 7.x.x Rails versions
+      # Run against the latest 6.x.x and 7.x.x Rails versions
       matrix:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -16,8 +16,9 @@ jobs:
       # Get latest Rails versions for 6.x.x and 7.x.x
       - id: compute-outputs
         name: Compute outputs
+        # fetches current Rails versions numbers > 5 and not 'beta'
         run: |
-          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq 'group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 5)' | jq -s -c)
+          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq '[.[] | select(.number | test("beta") | not)] | group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 5)' | jq -s -c)
           echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   build-rails:
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=build /rails /rails
 WORKDIR /rails/mail-notify-integration
 
 # add Mail Notify to the Gemfile
-ARG MAIL_NOTIFY_BRANCH=v2
+ARG MAIL_NOTIFY_BRANCH=2.0.0
 RUN echo "gem 'mail-notify', git: 'https://github.com/dxw/mail-notify', branch: '${MAIL_NOTIFY_BRANCH}'" >> Gemfile
 
 # install the mail-notify gem, we do this here to keep the last container layer small to help caching

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# We want to support older Rubies
-ARG RUBY_VERSION=2.7.8
+ARG RUBY_VERSION=3.1.6
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim AS base
 
 # Rails app lives here
@@ -12,9 +11,6 @@ FROM base AS build
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential curl git
 
-# Install Nokigiri version that supports Ruby 2.7.8
-RUN gem install nokogiri -v 1.15.6
-
 # Install Rails
 ARG RAILS_VERSION=7.2.1
 RUN gem install rails -v ${RAILS_VERSION}
@@ -26,9 +22,6 @@ WORKDIR mail-notify-integration
 
 # install the gems into the bundle
 RUN bundle install
-
-# remove gems that will not work in Rails 5.2.8.1
-RUN if [ "${RAILS_VERSION}" = "5.2.8.1" ]; then bundle remove selenium-webdriver chromedriver-helper; fi
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # We want to support older Rubies
 ARG RUBY_VERSION=2.7.8
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim AS base
 
 # Rails app lives here
 WORKDIR /rails
 
 # Build stage
-FROM base as build
+FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -qq && \
 RUN gem install nokogiri -v 1.15.6
 
 # Install Rails
-ARG RAILS_VERSION=7.1.3.2
+ARG RAILS_VERSION=7.2.1
 RUN gem install rails -v ${RAILS_VERSION}
 
 # create empty Rails application, we don't need ActiveRecord or JavaScript


### PR DESCRIPTION
Supporting these is more effort than value so we will drop support.

This work only relates to our integration tests and not the gem itself.