### PR TITLE
Multiple calls to ActionMailer::Base#mail produces multiple Mail::Fields in the headers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,11 @@ Style/Documentation:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+  EnforcedStyle: no_space

--- a/lib/mail/notify/mailer.rb
+++ b/lib/mail/notify/mailer.rb
@@ -3,13 +3,14 @@
 module Mail
   module Notify
     ##
-    # The Mail Notify base Mailer class, overridden in Rails applications to provide the additional
-    # Notify behaviour along with the application behaviour.
+    # The Mail Notify base Mailer class, overridden in Rails applications to
+    # provide the additional Notify behaviour along with the application
+    # behaviour.
 
     class Mailer < ActionMailer::Base
       ##
-      # Set a default from address, will only be used in previews if a from address is not supplied
-      # by subclasses
+      # Set a default from address, will only be used in previews if a from
+      # address is not supplied by subclasses
 
       default from: "preview@notifications.service.gov.uk"
 
@@ -25,12 +26,17 @@ module Mail
       #
       # Add any additional headers in the options hash.
       #
-      # A default subject is supplied as ActionMailer requires one, however it will never be used as
-      # the subject is assumed to be managed in the Notify template.
+      # A default subject is supplied as ActionMailer requires one, however it
+      # will never be used as the subject is assumed to be managed in the
+      # Notify template.
 
       def template_mail(template_id, options)
         raise ArgumentError, "You must specify a Notify template ID" if template_id.blank?
-        raise ArgumentError, "You must specify a to address" if options[:to].nil? || options[:to].blank?
+
+        if options[:to].nil? || options[:to].blank?
+          raise ArgumentError,
+                "You must specify a to address"
+        end
 
         message.template_id = template_id
         message.reply_to_id = options[:reply_to_id]
@@ -42,9 +48,9 @@ module Mail
 
         headers[:subject] = "Subject managed in Notify" unless options[:subject]
 
-        # We have to set the html and the plain text content to nil to prevent Rails from looking
-        # for the content in the views. We replace nil with the content returned from Notify before
-        # sending or previewing
+        # We have to set the html and the plain text content to nil to prevent
+        # Rails from looking for the content in the views. We replace nil with
+        # the content returned from Notify before sending or previewing
         mail(headers) do |format|
           format.text { nil }
           format.html { nil }
@@ -76,19 +82,14 @@ module Mail
         subject = options[:subject]
         headers = options.except(:personalisation, :reply_to_id, :reference)
 
-        # we have to render the view for the message and grab the raw source, then we set that as the
-        # body in the personalisation for sending to the Notify API.
-        # Calling the #mail method is not idempotent. It modifies state by setting instance variables on the message. Specifically it sets @_message.
-        # mail generates message headers for the options passed in.
-        # each time it is called with the same headers it adds another header field.
-        #
-        # original_message = message.dup
+        # we have to render the view for the message and grab the raw source,
+        # then we set that as the body in the personalisation for sending to
+        # the Notify API.
         body = mail(headers).body.raw_source
 
-        # @_message = original_message
-
-        # The 'view mail' works by sending a subject and body as personalisation options, these are
-        # then used in the Notify template to provide content.
+        # The 'view mail' works by sending a subject and body as
+        # personalisation options, these are then used in the Notify template
+        # to provide content.
         message.personalisation = {subject: subject, body: body}
 
         mail(headers) do |format|

--- a/lib/mail/notify/mailer.rb
+++ b/lib/mail/notify/mailer.rb
@@ -38,7 +38,7 @@ module Mail
 
         message.personalisation = options[:personalisation] || {}
 
-        headers = options.except([:personalisation, :reply_to_id, :reference])
+        headers = options.except(:personalisation, :reply_to_id, :reference)
 
         headers[:subject] = "Subject managed in Notify" unless options[:subject]
 
@@ -74,11 +74,18 @@ module Mail
         message.reference = options[:reference]
 
         subject = options[:subject]
-        headers = options.except([:personalisation, :reply_to_id, :reference])
+        headers = options.except(:personalisation, :reply_to_id, :reference)
 
         # we have to render the view for the message and grab the raw source, then we set that as the
         # body in the personalisation for sending to the Notify API.
+        # Calling the #mail method is not idempotent. It modifies state by setting instance variables on the message. Specifically it sets @_message.
+        # mail generates message headers for the options passed in.
+        # each time it is called with the same headers it adds another header field.
+        #
+        # original_message = message.dup
         body = mail(headers).body.raw_source
+
+        # @_message = original_message
 
         # The 'view mail' works by sending a subject and body as personalisation options, these are
         # then used in the Notify template to provide content.

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -6,7 +6,8 @@ require "mailers/test_mailer"
 RSpec.describe Mail::Notify::Mailer do
   describe "#view_mail" do
     it "sets the message template id" do
-      message_params = {template_id: "template-id", to: "test.name@email.co.uk", subject: "Test subject"}
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject"}
 
       message = TestMailer.with(message_params).test_view_mail
 
@@ -14,7 +15,8 @@ RSpec.describe Mail::Notify::Mailer do
     end
 
     it "sets the message subject" do
-      message_params = {template_id: "template-id", to: "test.name@email.co.uk", subject: "Test subject"}
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject"}
 
       message = TestMailer.with(message_params).test_view_mail
 
@@ -23,7 +25,8 @@ RSpec.describe Mail::Notify::Mailer do
     end
 
     it "sets the message to address" do
-      message_params = {template_id: "template-id", to: "test.name@email.co.uk", subject: "Test subject"}
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject"}
 
       message = TestMailer.with(message_params).test_view_mail
 
@@ -32,7 +35,8 @@ RSpec.describe Mail::Notify::Mailer do
     end
 
     it "sets the subject on personalisation" do
-      message_params = {template_id: "template-id", to: "test.name@email.co.uk", subject: "Test subject"}
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject"}
 
       message = TestMailer.with(message_params).test_view_mail
 
@@ -40,7 +44,8 @@ RSpec.describe Mail::Notify::Mailer do
     end
 
     it "sets the body on personalisation" do
-      message_params = {template_id: "template-id", to: "test.name@email.co.uk", subject: "Test subject"}
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject"}
 
       message = TestMailer.with(message_params).test_view_mail
 
@@ -145,7 +150,8 @@ RSpec.describe Mail::Notify::Mailer do
     end
 
     it "sets the subject if one is passed, even though it will not be used" do
-      message_params = {template_id: "template-id", to: "test.name@email.co.uk", subject: "My subject"}
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "My subject"}
 
       message = TestMailer.with(message_params).test_template_mail
 

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe Mail::Notify::Mailer do
       expect(message.template_id).to eql("template-id")
     end
 
+    it "sets a custom value as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", custom_header: "custom"}
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header[:custom_header]).to be_a(Mail::Field)
+      expect(message.header[:custom_header].value).to eq('custom')
+    end
+
     it "does not set reply_to_id as a header" do
       message_params = {template_id: "template-id", to: "test.name@email.co.uk",
                         subject: "Test subject", reply_to_id: "123"}

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -14,6 +14,33 @@ RSpec.describe Mail::Notify::Mailer do
       expect(message.template_id).to eql("template-id")
     end
 
+    it "does not set reply_to_id as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", reply_to_id: "123"}
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header[:reply_to_id]).to be_nil
+    end
+
+    it "does not set reference as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", reference: "ref-123"}
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header[:reference]).to be_nil
+    end
+
+    it "does not set personalisation as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", personalisation: "Dear sir"}
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header[:personalisation]).to be_nil
+    end
+
     it "sets the message subject" do
       message_params = {template_id: "template-id", to: "test.name@email.co.uk",
                         subject: "Test subject"}
@@ -129,6 +156,33 @@ RSpec.describe Mail::Notify::Mailer do
       message = TestMailer.with(message_params).test_template_mail
 
       expect(message.template_id).to eql("template-id")
+    end
+
+    it "does not set reply_to_id as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", reply_to_id: "123"}
+
+      message = TestMailer.with(message_params).test_template_mail
+
+      expect(message.header[:reply_to_id]).to be_nil
+    end
+
+    it "does not set reference as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", reference: "ref-123"}
+
+      message = TestMailer.with(message_params).test_template_mail
+
+      expect(message.header[:reference]).to be_nil
+    end
+
+    it "does not set personalisation as a header" do
+      message_params = {template_id: "template-id", to: "test.name@email.co.uk",
+                        subject: "Test subject", personalisation: "Dear sir"}
+
+      message = TestMailer.with(message_params).test_template_mail
+
+      expect(message.header[:personalisation]).to be_nil
     end
 
     it "sets the message to address" do


### PR DESCRIPTION
## Description

When upgrading the mail-notify gem to v2.0, our test suite began to fail. Our test suite asserts that accessing the mail headers returns a single `Mail::Field`. When we upgraded we began seeing an array of `Mail:Field`.

After some debugging we see that the mail-notify gem has introduced a potential unintended bug.

In an effort to begin the conversation and offer a path to a solution I have produced this PR. I don't think it's near ready and it should be used as a starting point to explore a better solution. And should be more thoroughly tested.

[ActionMailer::Base#mail](https://github.com/rails/rails/blob/v7.2.1/actionmailer/lib/action_mailer/base.rb#L869)
[Use of @_message instance variable in AM::B](https://github.com/rails/rails/blob/1ecc84a71b3c13387408adea8a1aa18472500ad4/actionmailer/lib/action_mailer/base.rb#L646)
