### PR TITLE
Fix: Header handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog]
 
 ## [Unreleased]
 
+- Fixed a bug in `view_mail` and `template_mail` that meant the options were being
+  included in the preview email headers for no reason - thanks to @inulty-dfe
+
 ## [2.0.0] - 2024-04-01
 
 - Version 2.0.0 rewrites most of the gem, without altering the API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog]
 
 - Fixed a bug in `view_mail` and `template_mail` that meant the options were being
   included in the preview email headers for no reason - thanks to @inulty-dfe
+- Fixed a bug in `view_mail` that meant custom headers in the preview email were
+  duplicated - thanks to @inulty-dfe
 
 ## [2.0.0] - 2024-04-01
 

--- a/lib/mail/notify/mailer.rb
+++ b/lib/mail/notify/mailer.rb
@@ -38,7 +38,7 @@ module Mail
 
         message.personalisation = options[:personalisation] || {}
 
-        headers = options.except([:personalisation, :reply_to_id, :reference])
+        headers = options.except(:personalisation, :reply_to_id, :reference)
 
         headers[:subject] = "Subject managed in Notify" unless options[:subject]
 
@@ -74,7 +74,7 @@ module Mail
         message.reference = options[:reference]
 
         subject = options[:subject]
-        headers = options.except([:personalisation, :reply_to_id, :reference])
+        headers = options.except(:personalisation, :reply_to_id, :reference)
 
         # we have to render the view for the message and grab the raw source, then we set that as the
         # body in the personalisation for sending to the Notify API.

--- a/lib/mail/notify/mailer.rb
+++ b/lib/mail/notify/mailer.rb
@@ -76,9 +76,12 @@ module Mail
         subject = options[:subject]
         headers = options.except(:personalisation, :reply_to_id, :reference)
 
-        # we have to render the view for the message and grab the raw source, then we set that as the
+        # We have to render the view for the message and grab the raw source, then we set that as the
         # body in the personalisation for sending to the Notify API.
-        body = mail(headers).body.raw_source
+        #
+        # We do not pass the headers as the call to `mail` will keep adding headers resulting in
+        # duplication when we have to call it again later.
+        body = mail.body.raw_source
 
         # The 'view mail' works by sending a subject and body as personalisation options, these are
         # then used in the Notify template to provide content.

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -132,6 +132,20 @@ RSpec.describe Mail::Notify::Mailer do
       expect(message.header[:reply_to_id]).to be_nil
       expect(message.header[:reference]).to be_nil
     end
+
+    it "sets custom headers only once" do
+      message_params = {
+        template_id: "template-id",
+        to: "test.name@email.co.uk",
+        subject: "Test subject",
+        custom_header: "custom header value"
+      }
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header["custom-header"]).to be_a(Mail::Field)
+      expect(message.header["custom-header"].value).to eq("custom header value")
+    end
   end
 
   describe "#template_email" do
@@ -235,6 +249,20 @@ RSpec.describe Mail::Notify::Mailer do
       expect(message.header[:personalisation]).to be_nil
       expect(message.header[:reply_to_id]).to be_nil
       expect(message.header[:reference]).to be_nil
+    end
+
+    it "sets custom headers only once" do
+      message_params = {
+        template_id: "template-id",
+        to: "test.name@email.co.uk",
+        subject: "Test subject",
+        custom_header: "custom header value"
+      }
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header["custom-header"]).to be_a(Mail::Field)
+      expect(message.header["custom-header"].value).to eq("custom header value")
     end
   end
 

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe Mail::Notify::Mailer do
         ArgumentError, "You must specify a subject"
       )
     end
+
+    it "does not include the personalisation, reply_to_id or reference options in the headers" do
+      message_params = {
+        template_id: "template-id",
+        to: "test.name@email.co.uk",
+        subject: "Test subject",
+        personalisation: "test-personalisation",
+        reply_to_id: "test@replyto.com",
+        reference: "test-reference"
+      }
+
+      message = TestMailer.with(message_params).test_view_mail
+
+      expect(message.header[:personalisation]).to be_nil
+      expect(message.header[:reply_to_id]).to be_nil
+      expect(message.header[:reference]).to be_nil
+    end
   end
 
   describe "#template_email" do
@@ -201,6 +218,23 @@ RSpec.describe Mail::Notify::Mailer do
       message = TestMailer.with(message_params).test_template_mail
 
       expect(message.reference).to eql("test-reference")
+    end
+
+    it "does not include the personalisation, reply_to_id or reference options in the headers" do
+      message_params = {
+        template_id: "template-id",
+        to: "test.name@email.co.uk",
+        subject: "Test subject",
+        personalisation: "test-personalisation",
+        reply_to_id: "test@replyto.com",
+        reference: "test-reference"
+      }
+
+      message = TestMailer.with(message_params).test_template_mail
+
+      expect(message.header[:personalisation]).to be_nil
+      expect(message.header[:reply_to_id]).to be_nil
+      expect(message.header[:reference]).to be_nil
     end
   end
 


### PR DESCRIPTION
This work sets out to resolve the two issues reported in #162 by @inulty-dfe.

We fix the first issue on the call to `Hash.except`.

We then stop the potential for duplicate headers ending up in the Mail::Message, by only sending the headers once to `mail` in `view_mail`.

This work will form the basis of v2.0.1