### PR TITLE
Support one click unsubscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ view mailers.
   replies from your users
 - `reference`: A unique identifier you can create if necessary. This reference
   identifies a single unique notification or a batch of notifications
+- `one_click_unsubscribe_url`: The URL email client will POST to in order to
+  unsubscribe from the mailing list
 
 More information can be [found in the
 Notify docs](https://docs.notifications.service.gov.uk/ruby.html#send-an-email-arguments-personalisation-optional)

--- a/lib/mail/notify/delivery_method.rb
+++ b/lib/mail/notify/delivery_method.rb
@@ -17,7 +17,8 @@ module Mail
           email_address: message.to.first,
           personalisation: message.personalisation,
           email_reply_to_id: message.reply_to_id,
-          reference: message.reference
+          reference: message.reference,
+          one_click_unsubscribe_url: message.one_click_unsubscribe_url
         }
 
         client.send_email(params.compact)

--- a/lib/mail/notify/mailer.rb
+++ b/lib/mail/notify/mailer.rb
@@ -35,6 +35,7 @@ module Mail
         message.template_id = template_id
         message.reply_to_id = options[:reply_to_id]
         message.reference = options[:reference]
+        message.one_click_unsubscribe_url = options[:one_click_unsubscribe_url]
 
         message.personalisation = options[:personalisation] || {}
 

--- a/lib/mail/notify/message.rb
+++ b/lib/mail/notify/message.rb
@@ -3,7 +3,7 @@
 module Mail
   module Notify
     module Message
-      attr_accessor :template_id, :personalisation, :reply_to_id, :reference
+      attr_accessor :template_id, :personalisation, :reply_to_id, :reference, :one_click_unsubscribe_url
     end
   end
 end

--- a/spec/mail/notify/delivery_method_spec.rb
+++ b/spec/mail/notify/delivery_method_spec.rb
@@ -177,6 +177,25 @@ RSpec.describe Mail::Notify::DeliveryMethod do
   end
 
   describe "Notify optional fields" do
+    context "when no optional fields present" do
+      it "optional fields not present in the call to the Notify API" do
+        message = TestMailer.with(
+          template_id: "test-id",
+          to: "test.name@email.co.uk"
+        ).test_template_mail
+
+        notifications_client = mock_notifications_client
+
+        message.delivery_method.deliver!(message)
+
+        expect(notifications_client).to have_received(:send_email).with(
+          template_id: "test-id",
+          email_address: "test.name@email.co.uk",
+          personalisation: {}
+        )
+      end
+    end
+
     describe "email_reply_to_id" do
       it "is present in the API call when set" do
         message = TestMailer.with(
@@ -194,23 +213,6 @@ RSpec.describe Mail::Notify::DeliveryMethod do
           email_address: "test.name@email.co.uk",
           personalisation: {},
           email_reply_to_id: "test-reply-to-id"
-        )
-      end
-
-      it "is not present in the call to the Notify API when not set" do
-        message = TestMailer.with(
-          template_id: "test-id",
-          to: "test.name@email.co.uk"
-        ).test_template_mail
-
-        notifications_client = mock_notifications_client
-
-        message.delivery_method.deliver!(message)
-
-        expect(notifications_client).to have_received(:send_email).with(
-          template_id: "test-id",
-          email_address: "test.name@email.co.uk",
-          personalisation: {}
         )
       end
     end
@@ -234,11 +236,16 @@ RSpec.describe Mail::Notify::DeliveryMethod do
           reference: "test-reference"
         )
       end
+    end
 
-      it "is not present in the call to the Notify API when not set" do
+    describe "one_click_unsubscribe_url" do
+      it "is present in the API call when set" do
+        one_click_unsubscribe_url = "https://www.example.com/unsubscribe?opaque=123"
+
         message = TestMailer.with(
           template_id: "test-id",
-          to: "test.name@email.co.uk"
+          to: "test.name@email.co.uk",
+          one_click_unsubscribe_url:
         ).test_template_mail
 
         notifications_client = mock_notifications_client
@@ -248,7 +255,8 @@ RSpec.describe Mail::Notify::DeliveryMethod do
         expect(notifications_client).to have_received(:send_email).with(
           template_id: "test-id",
           email_address: "test.name@email.co.uk",
-          personalisation: {}
+          personalisation: {},
+          one_click_unsubscribe_url:
         )
       end
     end

--- a/spec/mail/notify/mailer_spec.rb
+++ b/spec/mail/notify/mailer_spec.rb
@@ -264,6 +264,21 @@ RSpec.describe Mail::Notify::Mailer do
       expect(message.header["custom-header"]).to be_a(Mail::Field)
       expect(message.header["custom-header"].value).to eq("custom header value")
     end
+
+    it "sets one_click_unsubscribe_url" do
+      one_click_unsubscribe_url = "https://www.example.com/unsubscribe?opaque=123"
+
+      message_params = {
+        template_id: "template-id",
+        to: "test.name@email.co.uk",
+        subject: "Test subject",
+        one_click_unsubscribe_url:
+      }
+
+      message = TestMailer.with(message_params).test_template_mail
+
+      expect(message.one_click_unsubscribe_url).to eql(one_click_unsubscribe_url)
+    end
   end
 
   describe "#blank_allowed" do


### PR DESCRIPTION
# Context

- Support `one_click_unsubscribe_url` used by official notify client

# Changes

- `one_click_unsubscribe_url` can now be passed to mailer which forwards onto official notify client
- Modified some tests which were duplicated across multiple blocks 
- Updated README to document the new feature

# Review notes

- I've tested this locally with scoped notify key and it addded the following headers (obfuscated)
```
List-Unsubscribe: <https://localhost:3000/some/end/point?opaque=123>
List-Unsubscribe-Post: List-Unsubscribe=One-Click
```
- Unfortunately the email client I have access to is either pants, doesn't support it or I can't figure out how to turn it on so couldn't do full end to end 