### PR TITLE
Update Ruby for Rails 8 integration

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -42,6 +42,7 @@ jobs:
           build-args: |
             RAILS_VERSION=${{ matrix.rails }}
             MAIL_NOTIFY_BRANCH=${{ github.head_ref || github.ref_name }}
+            RUBY_VERSION=3.2.6
           push: false
           tags: mail-notify-integration-rails-${{ matrix.rails }}:latest
           outputs: type=docker, dest=/tmp/rails-${{ matrix.rails }}-image.tar

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             RAILS_VERSION=${{ matrix.rails }}
-            MAIL_NOTIFY_BRANCH=${{ github.ref }}
+            MAIL_NOTIFY_BRANCH=${{ github.head_ref || github.ref_name }}
           push: false
           tags: mail-notify-integration-rails-${{ matrix.rails }}:latest
           outputs: type=docker, dest=/tmp/rails-${{ matrix.rails }}-image.tar


### PR DESCRIPTION
Now that Rails 8 is out, it is showing up in our intergration test
matrix, but it only supports Ruby > 3.2.

This passes a build arg to use 3.2.6 in out integration tests.
