### PR TITLE
Allow repo to be specified in integration tests

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -56,6 +56,7 @@ jobs:
           build-args: |
             RAILS_VERSION=${{ matrix.rails }}
             MAIL_NOTIFY_BRANCH=${{ github.head_ref || github.ref_name }}
+            MAIL_NOTIFY_REPO=${{ github.server_url }}/${{ github.repository }}
             RUBY_VERSION=${{ needs.set-ruby-version.outputs.RUBY_VERSION }}
           push: false
           tags: mail-notify-integration-rails-${{ matrix.rails }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ WORKDIR /rails/mail-notify-integration
 
 # add Mail Notify to the Gemfile
 ARG MAIL_NOTIFY_BRANCH=2.0.0
-RUN echo "gem 'mail-notify', git: 'https://github.com/dxw/mail-notify', branch: '${MAIL_NOTIFY_BRANCH}'" >> Gemfile
+ARG MAIL_NOTIFY_REPO='https://github.com/dxw/mail-notify'
+RUN echo "gem 'mail-notify', git: '${MAIL_NOTIFY_REPO}', branch: '${MAIL_NOTIFY_BRANCH}'" >> Gemfile
 
 # install the mail-notify gem, we do this here to keep the last container layer small to help caching
 RUN bundle install


### PR DESCRIPTION
This allows integration tests from external contributors to be run successfully (See https://github.com/dxw/mail-notify/pull/168)