### PR TITLE
Fix dependency issues

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -16,9 +16,9 @@ jobs:
       # Get latest Rails versions for 6.x.x and 7.x.x
       - id: compute-outputs
         name: Compute outputs
-        # fetches current Rails versions numbers > 5 and not 'beta'
+        # fetches current Rails versions numbers > 6 and not 'beta'
         run: |
-          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq '[.[] | select(.number | test("beta") | not)] | group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 5)' | jq -s -c)
+          rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq '[.[] | select(.number | test("beta") | not)] | group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 6)' | jq -s -c)
           echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   build-rails:
     strategy:

--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "debug"
   spec.add_development_dependency "rails", "7.2.2.1"
   spec.add_development_dependency "rake", "~> 13.2.1"
-  spec.add_development_dependency "rspec-rails", "~> 5.1"
+  spec.add_development_dependency "rspec-rails", "~> 7.1"
   spec.add_development_dependency "standard", "~> 1"
   spec.add_development_dependency "sqlite3", "~> 1.7.2"
   spec.add_development_dependency "webmock", "~> 3.23.0"

--- a/mail-notify.gemspec
+++ b/mail-notify.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.21"
   spec.add_development_dependency "simplecov-lcov"
   spec.add_development_dependency "debug"
-  spec.add_development_dependency "rails", "7.0.8"
+  spec.add_development_dependency "rails", "7.2.2.1"
   spec.add_development_dependency "rake", "~> 13.2.1"
   spec.add_development_dependency "rspec-rails", "~> 5.1"
   spec.add_development_dependency "standard", "~> 1"

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.show_previews = true
   config.consider_all_requests_local = true
-  config.action_mailer.preview_path = "#{Rails.root}/lib/mailer_previews"
+  config.action_mailer.preview_paths << "#{Rails.root}/lib/mailer_previews"
 
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {


### PR DESCRIPTION
Since the release of `concurrent-ruby` 1.3.4, our installs of Rails 6 have begun to fail when running integration tests. As this is a non-trivial issue to solve, and as Rails 6 is EOL anyway, let's stop running integration tests against this version of Rails. 

Additionally, older versions of Rails 7 are affected by this issue, so I've bumped our development dependencies to the latest version of Rails, and bumped rspec-rails too, as older versions are incompatible with the latest Rails 7.