### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,25 @@
+name: CodeQL Analysis
+
+on:
+  workflow_call:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          show-progress: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5f8171a638ada777af81d42b55959a643bb29017 # v3
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@5f8171a638ada777af81d42b55959a643bb29017 # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5f8171a638ada777af81d42b55959a643bb29017 # v3

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -1,7 +1,9 @@
 name: Rails integration tests
 
 on:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -55,8 +55,6 @@ jobs:
           file: ./Dockerfile
           build-args: |
             RAILS_VERSION=${{ matrix.rails }}
-            MAIL_NOTIFY_BRANCH=${{ github.head_ref || github.ref_name }}
-            MAIL_NOTIFY_REPO=${{ github.server_url }}/${{ github.repository }}
             RUBY_VERSION=${{ needs.set-ruby-version.outputs.RUBY_VERSION }}
           push: false
           tags: mail-notify-integration-rails-${{ matrix.rails }}:latest

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -9,6 +9,11 @@ on:
       - main
 
 jobs:
+  codeql-sast:
+    name: CodeQL scan
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      security-events: write
   set-matrix:
     runs-on: ubuntu-latest
     name: Set Rails versions
@@ -43,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and cache Docker containers
     needs:
+      - codeql-sast
       - set-matrix
       - set-ruby-version
     steps:
@@ -76,6 +82,7 @@ jobs:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
     needs:
+      - codeql-sast
       - set-matrix
       - set-ruby-version
       - build-rails
@@ -101,6 +108,7 @@ jobs:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
     needs:
+      - codeql-sast
       - set-matrix
       - set-ruby-version
       - build-rails

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,8 @@ COPY --from=build /rails /rails
 WORKDIR /rails/mail-notify-integration
 
 # add Mail Notify to the Gemfile
-ARG MAIL_NOTIFY_BRANCH=2.0.0
-ARG MAIL_NOTIFY_REPO='https://github.com/dxw/mail-notify'
-RUN echo "gem 'mail-notify', git: '${MAIL_NOTIFY_REPO}', branch: '${MAIL_NOTIFY_BRANCH}'" >> Gemfile
+COPY . ../mail-notify
+RUN echo "gem 'mail-notify', path: '../mail-notify'" >> Gemfile
 
 # install the mail-notify gem, we do this here to keep the last container layer small to help caching
 RUN bundle install


### PR DESCRIPTION
This is a further improvement to allow the integration tests to run with forked repos (see https://github.com/dxw/mail-notify/pull/168) - we're running the integration tests on the `pull_request_target` event, which runs the action in the context of this repo (albeit the `main` branch), pulling down the changes from the forked repo.

There are some security issues in this (see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/), but we require approval from repo owners to run actions from external contributors, so this risk is small.

As an additional bit of belt and braces, I've added a CodeQL step to run BEFORE we run integration tests, so we have an extra belt and braces operation in case something is missed.