### PR TITLE
Run integration tests after workflow run

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,10 @@
 name: CodeQL Analysis
 
 on:
-  workflow_call:
-
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,7 @@
 name: CodeQL Analysis
 
+permissions: {}
+
 on:
   pull_request:
   push:
@@ -16,6 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           show-progress: false
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5f8171a638ada777af81d42b55959a643bb29017 # v3

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,7 @@
 name: Linting
+
+permissions: {}
+
 on:
   pull_request:
   push:
@@ -11,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: Publish to rubygems
 
+permissions: {}
+
 on:
   push:
     tags:
@@ -10,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
     - name: Setup Rubygems

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -67,15 +67,15 @@ jobs:
             RAILS_VERSION=${{ matrix.rails }}
             RUBY_VERSION=${{ needs.set-ruby-version.outputs.RUBY_VERSION }}
           push: false
-          tags: mail-notify-integration-rails-${{ matrix.rails }}:latest
-          outputs: type=docker, dest=/tmp/rails-${{ matrix.rails }}-image.tar
-          cache-from: type=gha,scope=build-${{ matrix.rails }}
-          cache-to: type=gha,mode=min,scope=build-${{ matrix.rails }}
+          tags: mail-notify-integration-rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}:latest
+          outputs: type=docker, dest=/tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
+          cache-from: type=gha,scope=build-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}
+          cache-to: type=gha,mode=min,scope=build-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rails-${{ matrix.rails }}-image
-          path: /tmp/rails-${{ matrix.rails }}-image.tar
+          name: rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image
+          path: /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
   mailer-previews:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -1,5 +1,7 @@
 name: Rails integration tests
 
+permissions: {}
+
 on:
   workflow_run:
     workflows: [CodeQL Analysis, Linting, Unit tests]
@@ -30,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - id: set-ruby-version
         name: Set Ruby version
         run: |
@@ -50,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and cache

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -1,20 +1,14 @@
 name: Rails integration tests
 
 on:
-  pull_request_target:
-    branches:
-      - main
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CodeQL Analysis, Linting, Unit tests]
+    types:
+      - completed
 
 jobs:
-  codeql-sast:
-    name: CodeQL scan
-    uses: ./.github/workflows/codeql.yml
-    permissions:
-      security-events: write
   set-matrix:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Set Rails versions
     outputs:
@@ -28,6 +22,7 @@ jobs:
           rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq '[.[] | select(.number | test("beta") | not)] | group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 6)' | jq -s -c)
           echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   set-ruby-version:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Set Ruby version
     outputs:
@@ -40,6 +35,7 @@ jobs:
         run: |
           echo "RUBY_VERSION=$(cat .ruby-version)" >> $GITHUB_OUTPUT
   build-rails:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +71,7 @@ jobs:
           name: rails-${{ matrix.rails }}-image
           path: /tmp/rails-${{ matrix.rails }}-image.tar
   mailer-previews:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       # Run against the latest 6.x.x and 7.x.x Rails versions
@@ -101,6 +98,7 @@ jobs:
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
           mail-notify-integration-rails-${{ matrix.rails }}:latest bin/rails test:system
   sending:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       # Run against the latest 5.x.x, 6.x.x and 7.x.x Rails versions

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,5 @@
 name: Unit tests
+permissions: {}
 on:
   pull_request:
   push:
@@ -14,6 +15,8 @@ jobs:
     name: Run specs and coverage report
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
It turns out that `pull_request_target` runs regardless of permissions, as code that is run is considered to be trusted, which we don’t necessarily want.

Changing this to `workflow_run` ensures that the action is ONLY run after the rest of the CI runs (which will need to be accepted for external contributions). Like `pull_request_target`, `workflow_run` triggers have access to secrets, but won’t get triggered until the other actions are approved and have run.