### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: CodeQL Analysis
 
-permissions: {}
+permissions:
+  security-events: write
 
 on:
   pull_request:

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -91,16 +91,16 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: rails-${{ matrix.rails }}-image
+          name: rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image
           path: /tmp
       - name: Load image
-        run: docker load --input /tmp/rails-${{ matrix.rails }}-image.tar
+        run: docker load --input /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
       - name: Run integration tests
         env:
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-${{ matrix.rails }}:latest bin/rails test:system
+          mail-notify-integration-rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}:latest bin/rails test:system
   sending:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
@@ -117,16 +117,16 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: rails-${{ matrix.rails }}-image
+          name: rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image
           path: /tmp
       - name: Load image
-        run: docker load --input /tmp/rails-${{ matrix.rails }}-image.tar
+        run: docker load --input /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
       - name: Run integration tests
         env:
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
-          mail-notify-integration-rails-${{ matrix.rails }}:latest bin/rails test
+          mail-notify-integration-rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}:latest bin/rails test
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -48,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and cache Docker containers
     needs:
-      - codeql-sast
       - set-matrix
       - set-ruby-version
     steps:
@@ -85,7 +84,6 @@ jobs:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
     needs:
-      - codeql-sast
       - set-matrix
       - set-ruby-version
       - build-rails
@@ -112,7 +110,6 @@ jobs:
         rails: ${{ fromJSON(needs.set-matrix.outputs.RAILS_VERSIONS) }}
     runs-on: ubuntu-latest
     needs:
-      - codeql-sast
       - set-matrix
       - set-ruby-version
       - build-rails

--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   workflow_run:
-    workflows: [CodeQL Analysis, Linting, Unit tests]
+    workflows: ["CodeQL Analysis"]
     types:
       - completed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl git
+    apt-get install --no-install-recommends -y build-essential curl git libyaml-dev
 
 # Install Rails
 ARG RAILS_VERSION=7.2.1


### PR DESCRIPTION
After https://github.com/dxw/mail-notify/pull/174 we discovered that the integration tests were failing to run. I ended up forking the repo and making some changes to my `main` branch to figure out what was going on. I now [have them running in my branch](https://github.com/pezholio/mail-notify/actions/runs/13988432478) (up until the tests actually run as my repo doesn't have the required secret), so these changes should fix the issue.

Be aware that the integration tests still won't run successfully in this branch, as `workflow_run` actions are triggered against the workflow in the `main` branch. Once this is merged, we should be back in action! 😅 