### PR TITLE
Migrate to using a reusable workflow for CI

### DIFF
--- a/.github/workflows/reusable.yml
+++ b/.github/workflows/reusable.yml
@@ -3,14 +3,19 @@ name: Rails integration tests
 permissions: {}
 
 on:
-  workflow_run:
-    workflows: ["Unit tests"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+        placeholder:
+            description: "placeholder"
+            type: string
+            required: false
+    secrets:
+        notify-api-key:
+            required: true
 
+        
 jobs:
   set-matrix:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Set Rails versions
     outputs:
@@ -24,7 +29,6 @@ jobs:
           rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq '[.[] | select(.number | test("beta") | not)] | group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 6)' | jq -s -c)
           echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   set-ruby-version:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Set Ruby version
     outputs:
@@ -39,7 +43,6 @@ jobs:
         run: |
           echo "RUBY_VERSION=$(cat .ruby-version)" >> $GITHUB_OUTPUT
   build-rails:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +79,6 @@ jobs:
           name: rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image
           path: /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
   mailer-previews:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       # Run against the latest 6.x.x and 7.x.x Rails versions
@@ -97,12 +99,11 @@ jobs:
         run: docker load --input /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
       - name: Run integration tests
         env:
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
+          NOTIFY_API_KEY: ${{ secrets.notify-api-key }}
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
           mail-notify-integration-rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}:latest bin/rails test:system
   sending:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       # Run against the latest 5.x.x, 6.x.x and 7.x.x Rails versions
@@ -123,7 +124,7 @@ jobs:
         run: docker load --input /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
       - name: Run integration tests
         env:
-          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
+          NOTIFY_API_KEY: ${{ secrets.notify-api-key }}
         run: |
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
           mail-notify-integration-rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}:latest bin/rails test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,17 +27,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           fail-on-error: false
-  results:
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    name: All unit tests
-    needs: [ unit-tests ]
-    steps:
-      # If any of the previous actions failed, we return a non-zero exit code
-      - run: exit 1
-        if: >-
-          ${{
-               contains(needs.*.result, 'failure')
-            || contains(needs.*.result, 'cancelled')
-            || contains(needs.*.result, 'skipped')
-          }}
+  reusable:
+    uses: dxw/mail-notify/.github/workflows/reusable.yml@reusable
+    secrets:
+      notify-api-key: ${{secrets.NOTIFY_API_KEY}}


### PR DESCRIPTION
Currently this relies on the "reusable" branch for test purposes.