### PR TITLE
Run integration tests safely

### DIFF
--- a/.github/workflows/rails-integration-tests.yml
+++ b/.github/workflows/rails-integration-tests.yml
@@ -3,16 +3,32 @@ name: Rails integration tests
 permissions: {}
 
 on:
-  workflow_run:
-    workflows: ["Unit tests"]
-    types:
-      - completed
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
+  check-user-permission:
+    runs-on: ubuntu-latest
+    name: Check user permission
+    steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
   set-matrix:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Set Rails versions
+    needs:
+      - check-user-permission
     outputs:
       RAILS_VERSIONS: ${{ steps.compute-outputs.outputs.RAILS_VERSIONS }}
     steps:
@@ -24,9 +40,10 @@ jobs:
           rails_versions=$(curl https://rubygems.org/api/v1/versions/rails.json | jq '[.[] | select(.number | test("beta") | not)] | group_by(.number[:1])[] | (.[0].number) | select(.[:1]|tonumber > 6)' | jq -s -c)
           echo "RAILS_VERSIONS=$rails_versions" >> $GITHUB_OUTPUT
   set-ruby-version:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Set Ruby version
+    needs:
+      - check-user-permission
     outputs:
       RUBY_VERSION: ${{ steps.set-ruby-version.outputs.RUBY_VERSION }}
     steps:
@@ -39,7 +56,6 @@ jobs:
         run: |
           echo "RUBY_VERSION=$(cat .ruby-version)" >> $GITHUB_OUTPUT
   build-rails:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +92,6 @@ jobs:
           name: rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image
           path: /tmp/rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}-image.tar
   mailer-previews:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       # Run against the latest 6.x.x and 7.x.x Rails versions
@@ -102,7 +117,6 @@ jobs:
           docker run --rm -e "NOTIFY_API_KEY=$NOTIFY_API_KEY" \
           mail-notify-integration-rails-${{ matrix.rails }}-${{ needs.set-ruby-version.outputs.RUBY_VERSION }}:latest bin/rails test:system
   sending:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       # Run against the latest 5.x.x, 6.x.x and 7.x.x Rails versions


### PR DESCRIPTION
This tweaks the integration tests to run on `pull_request_target`.

Because `pull_request_target` actions run regardless of if the repo owner has approved them, we first check if the person who triggered the run has admin permissions on the repo. If they don’t, then the action exits early and fails.

Then once the code has been reviewed and the other actions have been approved, an admin user can rerun the workflow with the correct permissions.